### PR TITLE
Fix three linux bugs

### DIFF
--- a/.github/workflows/push-nonmaster.yml
+++ b/.github/workflows/push-nonmaster.yml
@@ -12,9 +12,11 @@ jobs:
       matrix:
         os: [macos-10.15, macos-latest, ubuntu-18.04, ubuntu-latest]
         swift: ["4.2", "5.0", "5.1", "5.2", "5.3", "5.4", "5.5"]
-          #exclude:
-          #- os: macos-latest
-          #  swift: "4.2"
+        exclude:
+          - os: macos-latest
+            swift: "4.2"
+          - os: macos-10.15
+            swift: "4.2"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/push-nonmaster.yml
+++ b/.github/workflows/push-nonmaster.yml
@@ -17,6 +17,8 @@ jobs:
             swift: "4.2"
           - os: macos-10.15
             swift: "4.2"
+          - os: macos-10.15
+            swift: "5.1"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/push-nonmaster.yml
+++ b/.github/workflows/push-nonmaster.yml
@@ -13,25 +13,6 @@ jobs:
       matrix:
         os: [macos-10.15, macos-latest, ubuntu-18.04, ubuntu-latest]
         swift: ["4.2", "5.0", "5.1", "5.2", "5.3", "5.4", "5.5"]
-        exclude:
-          - os: macos-10.15
-            swift: "4.2"
-          - os: macos-10.15
-            swift: "5.1"
-          - os: macos-10.15
-            swift: "5.2"
-          - os: macos-latest
-            swift: "4.2"
-          - os: macos-latest
-            swift: "5.0"
-          - os: macos-latest
-            swift: "5.1"
-          - os: macos-latest
-            swift: "5.2"
-          - os: macos-latest
-            swift: "5.3"
-          - os: macos-latest
-            swift: "5.4"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/push-nonmaster.yml
+++ b/.github/workflows/push-nonmaster.yml
@@ -9,6 +9,7 @@ jobs:
   test:
     name: Test Swift ${{ matrix.swift }}.x on ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-10.15, macos-latest, ubuntu-18.04, ubuntu-latest]
         swift: ["4.2", "5.0", "5.1", "5.2", "5.3", "5.4", "5.5"]

--- a/.github/workflows/push-nonmaster.yml
+++ b/.github/workflows/push-nonmaster.yml
@@ -17,8 +17,14 @@ jobs:
             swift: "4.2"
           - os: macos-10.15
             swift: "4.2"
+          - os: macos-latest
+            swift: "5.1"
           - os: macos-10.15
             swift: "5.1"
+          - os: macos-latest
+            swift: "5.2"
+          - os: macos-10.15
+            swift: "5.2"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/push-nonmaster.yml
+++ b/.github/workflows/push-nonmaster.yml
@@ -13,6 +13,31 @@ jobs:
       matrix:
         os: [macos-10.15, macos-latest, ubuntu-18.04, ubuntu-latest]
         swift: ["4.2", "5.0", "5.1", "5.2", "5.3", "5.4", "5.5"]
+        exclude:
+          - os: macos-10.15
+            swift: "4.2"
+          - os: macos-10.15
+            swift: "5.1"
+          - os: macos-10.15
+            swift: "5.2"
+          - os: macos-latest
+            swift: "4.2"
+          - os: macos-latest
+            swift: "5.0"
+          - os: macos-latest
+            swift: "5.1"
+          - os: macos-latest
+            swift: "5.2"
+          - os: macos-latest
+            swift: "5.3"
+          - os: macos-latest
+            swift: "5.4"
+          - os: ubuntu-latest
+            swift: "4.2"
+          - os: ubuntu-latest
+            swift: "5.0"
+          - os: ubuntu-latest
+            swift: "5.1"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/push-nonmaster.yml
+++ b/.github/workflows/push-nonmaster.yml
@@ -18,6 +18,8 @@ jobs:
           - os: macos-10.15
             swift: "4.2"
           - os: macos-latest
+            swift: "5.0"
+          - os: macos-latest
             swift: "5.1"
           - os: macos-10.15
             swift: "5.1"

--- a/.github/workflows/push-nonmaster.yml
+++ b/.github/workflows/push-nonmaster.yml
@@ -13,20 +13,22 @@ jobs:
         os: [macos-10.15, macos-latest, ubuntu-18.04, ubuntu-latest]
         swift: ["4.2", "5.0", "5.1", "5.2", "5.3", "5.4", "5.5"]
         exclude:
-          - os: macos-latest
+          - os: macos-10.15
             swift: "4.2"
           - os: macos-10.15
+            swift: "5.1"
+          - os: macos-10.15
+            swift: "5.2"
+          - os: macos-latest
             swift: "4.2"
           - os: macos-latest
             swift: "5.0"
           - os: macos-latest
             swift: "5.1"
-          - os: macos-10.15
-            swift: "5.1"
           - os: macos-latest
             swift: "5.2"
-          - os: macos-10.15
-            swift: "5.2"
+          - os: macos-latest
+            swift: "5.3"
           - os: macos-latest
             swift: "5.4"
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/push-nonmaster.yml
+++ b/.github/workflows/push-nonmaster.yml
@@ -27,6 +27,8 @@ jobs:
             swift: "5.2"
           - os: macos-10.15
             swift: "5.2"
+          - os: macos-latest
+            swift: "5.4"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/push-nonmaster.yml
+++ b/.github/workflows/push-nonmaster.yml
@@ -1,0 +1,25 @@
+name: Push (non-master)
+
+on:
+  push:
+    branches-ignore:
+      - master
+
+jobs:
+  test:
+    name: Test Swift ${{ matrix.swift }}.x on ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-10.15, macos-latest, ubuntu-18.04, ubuntu-latest]
+        swift: ["4.2", "5.0", "5.1", "5.2", "5.3", "5.4", "5.5"]
+          #exclude:
+          #- os: macos-latest
+          #  swift: "4.2"
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: fwal/setup-swift@v1
+        with:
+          swift-version: ${{ matrix.swift }}
+      - run: swift --version
+      - run: swift test

--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -2,7 +2,7 @@ clean: true
 author: Samasaur
 author_url: https://github.com/Samasaur1
 module: SwiftIP
-module_version: 2.2.0
+module_version: 2.2.1
 # docset_icon:
 github_url: https://github.com/Samasaur1/SwiftIP
 # github_file_prefix:

--- a/Sources/SwiftIP/SwiftIP.swift
+++ b/Sources/SwiftIP/SwiftIP.swift
@@ -1,7 +1,10 @@
 import Foundation
 
-#if !os(macOS)
+#if canImport(FoundationNetworking)
 import FoundationNetworking
+#endif
+
+#if !os(macOS)
 extension sockaddr {
     var sa_len: Int {
         switch Int32(sa_family) {

--- a/Sources/SwiftIP/SwiftIP.swift
+++ b/Sources/SwiftIP/SwiftIP.swift
@@ -1,5 +1,18 @@
 import Foundation
 
+#if !os(macOS)
+import FoundationNetworking
+extension sockaddr {
+    var sa_len: Int {
+        switch Int32(sa_family) {
+        case AF_INET: return MemoryLayout<sockaddr_in>.size
+        case AF_INET6: return MemoryLayout<sockaddr_in6>.size
+        default: return MemoryLayout<sockaddr_storage>.size // something else
+        }
+    }
+}
+#endif
+
 /// The class that manages finding the device's IP address(es).
 public final class IP {
     /// The version of the Internet Protocol (IP) that you want to fetch
@@ -57,7 +70,11 @@ public final class IP {
                 guard let pointer = ptr else {
                     return nil
                 }
+#if os(macOS)
                 let flags = Int32(pointer.pointee.ifa_flags)
+#else
+                let flags = Int(pointer.pointee.ifa_flags)
+#endif
                 var addr = pointer.pointee.ifa_addr.pointee
 
                 // Check for running IPv4, IPv6 interfaces. Skip the loopback interface.


### PR DESCRIPTION
1. URLSession and related classes are in FoundationNetworking, not Foundation, on Linux
2. sockaddr does not have an sa_len property on Linux, so we synthesize one with an extension
3. The interfaces that flags is bitwise ANDed with are the native word size, not necessarily 32 bits. Therefore flags must also be the native word size. (n.b. this is the thing I am least sure about being a general Linux bug and most likely to be a quirk of the machine I built on)