### PR TITLE
Fix conditional compilation (fixing all platforms)

### DIFF
--- a/.github/workflows/push-nonmaster.yml
+++ b/.github/workflows/push-nonmaster.yml
@@ -11,37 +11,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-10.15, macos-latest, ubuntu-18.04, ubuntu-latest]
-        swift: ["4.2", "5.0", "5.1", "5.2", "5.3", "5.4", "5.5"]
-        exclude:
-          - os: macos-10.15
-            swift: "4.2"
-          - os: macos-10.15
-            swift: "5.1"
-          - os: macos-10.15
-            swift: "5.2"
-          - os: macos-latest
-            swift: "4.2"
-          - os: macos-latest
-            swift: "5.0"
-          - os: macos-latest
-            swift: "5.1"
-          - os: macos-latest
-            swift: "5.2"
-          - os: macos-latest
-            swift: "5.3"
-          - os: macos-latest
-            swift: "5.4"
-          - os: ubuntu-latest
-            swift: "4.2"
-          - os: ubuntu-latest
-            swift: "5.0"
-          - os: ubuntu-latest
-            swift: "5.1"
+        os: [macos-latest, ubuntu-latest]
+        swift: ["4.2", "5.0", "5.1", "5.2", "5.3", "5.4", "5.5", "5.6", "5.7", "5.8", "5.9"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: fwal/setup-swift@v1
+      - uses: swift-actions/setup-swift@v1
         with:
           swift-version: ${{ matrix.swift }}
       - run: swift --version

--- a/Sources/SwiftIP/SwiftIP.swift
+++ b/Sources/SwiftIP/SwiftIP.swift
@@ -73,11 +73,7 @@ public final class IP {
                 guard let pointer = ptr else {
                     return nil
                 }
-#if os(macOS)
                 let flags = Int32(pointer.pointee.ifa_flags)
-#else
-                let flags = Int(pointer.pointee.ifa_flags)
-#endif
                 var addr = pointer.pointee.ifa_addr.pointee
 
                 // Check for running IPv4, IPv6 interfaces. Skip the loopback interface.

--- a/Sources/SwiftIP/SwiftIP.swift
+++ b/Sources/SwiftIP/SwiftIP.swift
@@ -73,7 +73,11 @@ public final class IP {
                 guard let pointer = ptr else {
                     return nil
                 }
+#if os(Linux)
+                let flags = Int(pointer.pointee.ifa_flags)
+#else
                 let flags = Int32(pointer.pointee.ifa_flags)
+#endif
                 var addr = pointer.pointee.ifa_addr.pointee
 
                 // Check for running IPv4, IPv6 interfaces. Skip the loopback interface.


### PR DESCRIPTION
When I merged #11, I added some conditional compilation that tried to use `Int32` for `ifflags` on Apple platforms, and `Int` on non-Apple platforms. However, I got my check backwards, so it broke on all platforms. Although I tried using `Int32` on all platforms, this still doesn't work, so I flipped the check to fix this package.

Unfortunately, I am having issues with the GitHub Action I am using for testing (it appears to be unmaintained?), but this fix has passed its tests on the three latest versions of Swift on both macOS and Ubuntu, which is good enough to merge — I am fairly certain that other versions will succeed in practice.